### PR TITLE
used cursor to upgrade to icicle main (to check thoroughly before merge) 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,10 @@ members = ["icicle-blake3-air", "icicle-trace", "icicle-keccak-air"]
 
 [workspace.dependencies]
 blake3 = "1.5"
-icicle-runtime = { git = "https://github.com/ingonyama-zk/icicle.git", rev = "505ee499c00cd07150803d1c4ed319fbb251a15f" }
-icicle-core = { git = "https://github.com/ingonyama-zk/icicle.git", rev = "505ee499c00cd07150803d1c4ed319fbb251a15f" }
-icicle-babybear = { git = "https://github.com/ingonyama-zk/icicle.git", rev = "505ee499c00cd07150803d1c4ed319fbb251a15f" }
-icicle-hash = { git = "https://github.com/ingonyama-zk/icicle.git", rev = "505ee499c00cd07150803d1c4ed319fbb251a15f" }
+icicle-runtime = { git = "https://github.com/ingonyama-zk/icicle.git", branch = "main" }
+icicle-core = { git = "https://github.com/ingonyama-zk/icicle.git", branch = "main" }
+icicle-babybear = { git = "https://github.com/ingonyama-zk/icicle.git", branch = "main" }
+icicle-hash = { git = "https://github.com/ingonyama-zk/icicle.git", branch = "main" }
 
 rand = "0.8.5"
 rayon = "1.7.0"

--- a/icicle-keccak-air/src/air.rs
+++ b/icicle-keccak-air/src/air.rs
@@ -4,7 +4,6 @@
 
 use alloc::vec::Vec;
 use core::borrow::Borrow;
-use icicle_trace::utils::{andn, xor, xor3};
 
 use icicle_core::traits::{Arithmetic, FieldImpl};
 use icicle_trace::{Air, AirBuilder, BaseAir};
@@ -49,17 +48,17 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
         let local: &KeccakCols<AB::Var> = (*local).borrow();
         let next: &KeccakCols<AB::Var> = (*next).borrow();
 
-        let first_step = local.step_flags[0].clone();
-        let final_step = local.step_flags[NUM_ROUNDS - 1].clone();
-        let not_final_step = AB::Expr::one() - final_step;
+        let first_step = local.step_flags[0];
+        let final_step = local.step_flags[NUM_ROUNDS - 1];
+        let not_final_step = builder.one() - final_step.into();
 
         // If this is the first step, the input A must match the preimage.
         for y in 0..5 {
             for x in 0..5 {
                 for limb in 0..U64_LIMBS {
-                    builder.when(first_step.clone()).assert_eq(
-                        local.preimage[y][x][limb].clone(),
-                        local.a[y][x][limb].clone(),
+                    builder.when(first_step).assert_eq(
+                        local.preimage[y][x][limb],
+                        local.a[y][x][limb],
                     );
                 }
             }
@@ -70,23 +69,22 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
             for x in 0..5 {
                 for limb in 0..U64_LIMBS {
                     builder
-                        .when(not_final_step.clone())
-                        .when_transition()
+                        .when(not_final_step.clone() * builder.is_transition())
                         .assert_eq(
-                            local.preimage[y][x][limb].clone(),
-                            next.preimage[y][x][limb].clone(),
+                            local.preimage[y][x][limb],
+                            next.preimage[y][x][limb],
                         );
                 }
             }
         }
 
         // The export flag must be 0 or 1.
-        builder.assert_bool(local.export.clone());
+        builder.assert_bool(local.export);
 
         // If this is not the final step, the export flag must be off.
         builder
             .when(not_final_step.clone())
-            .assert_zero(local.export.clone());
+            .assert_zero(local.export);
 
         // C'[x, z] = xor(C[x, z], C[x - 1, z], C[x + 1, z - 1]).
         // Note that if all entries of C are boolean, the arithmetic generalization
@@ -95,13 +93,13 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
         for x in 0..5 {
             for z in 0..64 {
                 // Check to ensure all entries of C are bools.
-                builder.assert_bool(local.c[x][z].clone());
-                let xor = xor3::<AB::Expr>(
-                    local.c[x][z].clone().into(),
-                    local.c[(x + 4) % 5][z].clone().into(),
-                    local.c[(x + 1) % 5][(z + 63) % 64].clone().into(),
+                builder.assert_bool(local.c[x][z]);
+                let xor = builder.xor3(
+                    local.c[x][z],
+                    local.c[(x + 4) % 5][z],
+                    local.c[(x + 1) % 5][(z + 63) % 64],
                 );
-                let c_prime = local.c_prime[x][z].clone();
+                let c_prime = local.c_prime[x][z];
                 builder.assert_eq(c_prime, xor);
             }
         }
@@ -116,22 +114,24 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
         // This has the side effect of also range checking the limbs of A.
         for y in 0..5 {
             for x in 0..5 {
-                let get_bit = |z: usize| {
-                    let a_prime: AB::Var = local.a_prime[y][x][z].clone();
-                    let c: AB::Var = local.c[x][z].clone();
-                    let c_prime: AB::Var = local.c_prime[x][z].clone();
-                    xor3::<AB::Expr>(a_prime.into(), c.into(), c_prime.into())
+                let get_bit = |builder: &AB, z: usize| {
+                    let a_prime = local.a_prime[y][x][z];
+                    let c = local.c[x][z];
+                    let c_prime = local.c_prime[x][z];
+                    builder.xor3(a_prime, c, c_prime)
                 };
 
+                // Pre-check booleans for A' bits
+                for z in 0..64 {
+                    builder.assert_bool(local.a_prime[y][x][z]);
+                }
+
                 for limb in 0..U64_LIMBS {
-                    let a_limb = local.a[y][x][limb].clone();
-                    let computed_limb = (limb * BITS_PER_LIMB..(limb + 1) * BITS_PER_LIMB)
-                        .rev()
-                        .fold(AB::Expr::zero(), |acc, z| {
-                            // Check to ensure all entries of A' are bools.
-                            builder.assert_bool(local.a_prime[y][x][z].clone());
-                            acc.clone() + acc + get_bit(z)
-                        });
+                    let a_limb = local.a[y][x][limb];
+                    let computed_limb = builder.pack_bits_le(
+                        (limb * BITS_PER_LIMB..(limb + 1) * BITS_PER_LIMB)
+                            .map(|z| get_bit(builder, z))
+                    );
                     builder.assert_eq(computed_limb, a_limb);
                 }
             }
@@ -143,12 +143,11 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
         for x in 0..5 {
             for z in 0..64 {
                 let sum: AB::Expr = (0..5)
-                    .map(|y| local.a_prime[y][x][z].clone().into())
-                    .fold(AB::Expr::zero(), |acc, val| acc + val);
-                let diff = sum - local.c_prime[x][z].clone();
-                // This should be slightly faster than from_canonical_u8(4) for some fields.
-                let two = AB::Expr::one() + AB::Expr::one();
-                let four = two.clone() + two.clone();
+                    .map(|y| local.a_prime[y][x][z].into())
+                    .fold(builder.zero(), |acc, val| acc + val);
+                let diff = sum - local.c_prime[x][z].into();
+                let two = builder.two();
+                let four = builder.from_u32(4);
                 builder.assert_zero(diff.clone() * (diff.clone() - two) * (diff - four));
             }
         }
@@ -158,56 +157,58 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
         // this check also range checks A''.
         for y in 0..5 {
             for x in 0..5 {
-                let get_bit = |z| {
-                    let andn = andn::<AB::Expr>(
-                        local.b((x + 1) % 5, y, z).into(),
-                        local.b((x + 2) % 5, y, z).into(),
+                let get_bit = |builder: &AB, z| {
+                    let andn = builder.andn(
+                        local.b((x + 1) % 5, y, z),
+                        local.b((x + 2) % 5, y, z),
                     );
-                    xor::<AB::Expr>(local.b(x, y, z).into(), andn)
+                    builder.xor(local.b(x, y, z), andn)
                 };
 
                 for limb in 0..U64_LIMBS {
-                    let computed_limb = (limb * BITS_PER_LIMB..(limb + 1) * BITS_PER_LIMB)
-                        .rev()
-                        .fold(AB::Expr::zero(), |acc, z| acc.clone() + acc + get_bit(z));
-                    builder.assert_eq(computed_limb, local.a_prime_prime[y][x][limb].clone());
+                    let computed_limb = builder.pack_bits_le(
+                        (limb * BITS_PER_LIMB..(limb + 1) * BITS_PER_LIMB)
+                            .map(|z| get_bit(builder, z))
+                    );
+                    builder.assert_eq(computed_limb, local.a_prime_prime[y][x][limb]);
                 }
             }
         }
 
+        // Pre-check booleans for A''[0, 0] bits
+        for z in 0..64 {
+            builder.assert_bool(local.a_prime_prime_0_0_bits[z]);
+        }
+
         // A'''[0, 0] = A''[0, 0] XOR RC
         for limb in 0..U64_LIMBS {
-            let computed_a_prime_prime_0_0_limb = (limb * BITS_PER_LIMB
-                ..(limb + 1) * BITS_PER_LIMB)
-                .rev()
-                .fold(AB::Expr::zero(), |acc, z| {
-                    // Check to ensure the bits of A''[0, 0] are boolean.
-                    builder.assert_bool(local.a_prime_prime_0_0_bits[z].clone());
-                    acc.clone() + acc + local.a_prime_prime_0_0_bits[z].clone()
-                });
-            let a_prime_prime_0_0_limb = local.a_prime_prime[0][0][limb].clone();
+            let computed_a_prime_prime_0_0_limb = builder.pack_bits_le(
+                (limb * BITS_PER_LIMB..(limb + 1) * BITS_PER_LIMB)
+                    .map(|z| {
+                        local.a_prime_prime_0_0_bits[z]
+                    })
+            );
+            let a_prime_prime_0_0_limb = local.a_prime_prime[0][0][limb];
             builder.assert_eq(computed_a_prime_prime_0_0_limb, a_prime_prime_0_0_limb);
         }
 
-        let get_xored_bit = |i| {
-            let mut rc_bit_i = AB::Expr::zero();
+        let get_xored_bit = |builder: &AB, i: usize| {
+            let mut rc_bit_i = builder.zero();
             for r in 0..NUM_ROUNDS {
-                let this_round = local.step_flags[r].clone();
-                let this_round_constant = AB::Expr::from_u32((rc_value_bit(r, i) != 0) as u32);
+                let this_round = local.step_flags[r];
+                let this_round_constant = builder.from_u32((rc_value_bit(r, i) != 0) as u32);
                 rc_bit_i = rc_bit_i + this_round * this_round_constant;
             }
 
-            xor::<AB::Expr>(local.a_prime_prime_0_0_bits[i].clone().into(), rc_bit_i)
+            builder.xor(local.a_prime_prime_0_0_bits[i], rc_bit_i)
         };
 
         for limb in 0..U64_LIMBS {
-            let a_prime_prime_prime_0_0_limb = local.a_prime_prime_prime_0_0_limbs[limb].clone();
-            let computed_a_prime_prime_prime_0_0_limb = (limb * BITS_PER_LIMB
-                ..(limb + 1) * BITS_PER_LIMB)
-                .rev()
-                .fold(AB::Expr::zero(), |acc, z| {
-                    acc.clone() + acc + get_xored_bit(z)
-                });
+            let a_prime_prime_prime_0_0_limb = local.a_prime_prime_prime_0_0_limbs[limb];
+            let computed_a_prime_prime_prime_0_0_limb = builder.pack_bits_le(
+                (limb * BITS_PER_LIMB..(limb + 1) * BITS_PER_LIMB)
+                    .map(|z| get_xored_bit(builder, z))
+            );
             builder.assert_eq(
                 computed_a_prime_prime_prime_0_0_limb,
                 a_prime_prime_prime_0_0_limb,
@@ -219,10 +220,9 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
             for y in 0..5 {
                 for limb in 0..U64_LIMBS {
                     let output = local.a_prime_prime_prime(y, x, limb);
-                    let input = next.a[y][x][limb].clone();
+                    let input = next.a[y][x][limb];
                     builder
-                        .when_transition()
-                        .when(not_final_step.clone())
+                        .when(builder.is_transition() * not_final_step.clone())
                         .assert_eq(output, input);
                 }
             }

--- a/icicle-trace/src/check_constraints.rs
+++ b/icicle-trace/src/check_constraints.rs
@@ -91,6 +91,16 @@ where
         }
     }
 
+    fn zero(&self) -> Self::Expr {
+        F::zero()
+    }
+    fn one(&self) -> Self::Expr {
+        F::one()
+    }
+    fn from_u32(&self, val: u32) -> Self::Expr {
+        F::from_u32(val)
+    }
+
     fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
         assert_eq!(
             x.into(),

--- a/icicle-trace/src/symbolic_builder.rs
+++ b/icicle-trace/src/symbolic_builder.rs
@@ -136,6 +136,16 @@ impl<F: FieldImpl + Arithmetic> AirBuilder for SymbolicAirBuilder<F> {
         }
     }
 
+    fn zero(&self) -> Self::Expr {
+        SymbolicExpression::zero()
+    }
+    fn one(&self) -> Self::Expr {
+        SymbolicExpression::one()
+    }
+    fn from_u32(&self, val: u32) -> Self::Expr {
+        SymbolicExpression::from_u32(val)
+    }
+
     fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
         self.constraints.push(x.into());
     }


### PR DESCRIPTION
All examples are working!

Okay, here's a summary of the key changes made to fix the trait bound issues and get the examples compiling:

1.  **Redefined `AirBuilder::Expr`:**
    *   The core issue was that the `Expr` associated type in the `AirBuilder` trait (often fulfilled by `SymbolicExpression`) was incorrectly required to implement `FieldImpl` and `Arithmetic`.
    *   We removed these `FieldImpl`/`Arithmetic` bounds from `Expr`.
    *   Instead, we added the necessary *algebraic* bounds directly to `Expr`: `Clone`, `Add`, `Sub`, `Mul` (for operations between `Expr`, `F`, and `Var`), and `From<F>`, `From<Var>`. This reflects that `Expr` represents symbolic computations *over* a field `F`, rather than being a field itself.

2.  **Added `AirBuilder` Helper Methods:**
    *   Since `Expr` is no longer a field, we couldn't directly call methods like `Expr::zero()` or `Expr::one()`.
    *   We added helper methods `zero()`, `one()`, `two()`, and `from_u32()` to the `AirBuilder` trait itself. Implementers (like `SymbolicAirBuilder` and `DebugConstraintBuilder`) provide the logic to create constant expressions.

3.  **Refactored `SymbolicExpression`:**
    *   Removed the incorrect `impl FieldImpl for SymbolicExpression` and `impl Arithmetic for SymbolicExpression` blocks.
    *   Added static methods `zero()`, `one()`, and `from_u32()` to create constant `SymbolicExpression` instances, aligning with the builder helpers.
    *   Ensured its `Add`, `Sub`, `Mul`, `Neg` implementations worked correctly for symbolic manipulation, including optimizations for identity elements (adding zero, multiplying by one).

4.  **Moved Utility Functions into `AirBuilder`:**
    *   Functions like `xor`, `andn`, `xor3`, and `pack_bits_le` operate on expressions and need access to constants like `one()` and `two()`.
    *   We moved these into the `AirBuilder` trait as default methods. This gives them access to `self.one()`, `self.two()`, etc., via the builder instance.
    *   Code using these functions (in `utils.rs` and the AIR implementations) was updated to call them via the builder (e.g., `builder.xor(...)`).

5.  **Updated Builder Implementations:**
    *   `SymbolicAirBuilder`, `DebugConstraintBuilder`, and `FilteredAirBuilder` were updated to implement the new `zero()`, `one()`, `from_u32()` methods.
    *   Methods in `FilteredAirBuilder` (like `assert_eq`, `assert_one`, `assert_zero`) were made `pub` and added where missing to ensure they were accessible after filtering (`when_*` calls).

6.  **Updated AIR Implementations (Keccak, Blake3, Fib):**
    *   Calls to standalone utility functions were replaced with calls to the builder's methods (e.g., `xor(a, b)` became `builder.xor(a, b)`).
    *   Direct use of field constants (like `AB::Expr::one()`) was replaced with builder methods (`builder.one()`).
    *   Resolved borrowing errors by separating mutable operations (`assert_bool`) from closures that required immutable borrows of the builder (`pack_bits_le`).

Essentially, we clarified the distinction between the underlying field `F` and the symbolic expression type `Expr`, adjusted the `AirBuilder` trait to reflect this, and pushed expression-related helper functions into the trait so they could access necessary constants and operations through the builder instance.
